### PR TITLE
Fix error being thrown when querying user friends with private profile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -298,7 +298,7 @@ class SteamAPI {
       `/ISteamUser/GetFriendList/v1?steamid=${steamId}`
     );
 
-    return friends.length ? friends.map(friend => new Friend(friend)) : null;
+    return friends?.length ? friends.map(friend => new Friend(friend)) : null;
   }
 
   async getUserGroups(steamId: string) {


### PR DESCRIPTION
When querying a users who's profile is private friends is null. 

This causes an error to be thrown by using `.length`

I have added a conditional to this so it won't access `.length` if this is the case and will just go on to return null and not throw and error like originally intended.