### PR TITLE
Add `steamid` to `UserSummary`

### DIFF
--- a/src/classes/UserSummary.ts
+++ b/src/classes/UserSummary.ts
@@ -13,6 +13,8 @@ class Avatar {
 
 @ObjectType()
 class UserSummary {
+  @Field(() => String)
+  steamid;
   @Field(() => Avatar)
   avatar: Avatar;
   @Field(() => String)
@@ -50,6 +52,7 @@ class UserSummary {
   locCityId;
 
   constructor(playerSummary: SteamPlayerSummary) {
+    this.steamid = playerSummary.steamid;
     this.avatar = {
       default: playerSummary.avatar,
       medium: playerSummary.avatarmedium,

--- a/src/classes/UserSummary.ts
+++ b/src/classes/UserSummary.ts
@@ -14,7 +14,7 @@ class Avatar {
 @ObjectType()
 class UserSummary {
   @Field(() => String)
-  steamid;
+  steamId;
   @Field(() => Avatar)
   avatar: Avatar;
   @Field(() => String)
@@ -52,7 +52,7 @@ class UserSummary {
   locCityId;
 
   constructor(playerSummary: SteamPlayerSummary) {
-    this.steamid = playerSummary.steamid;
+    this.steamId = playerSummary.steamid;
     this.avatar = {
       default: playerSummary.avatar,
       medium: playerSummary.avatarmedium,

--- a/src/types/steamEntities.ts
+++ b/src/types/steamEntities.ts
@@ -267,6 +267,7 @@ export const personaStateMap = {
 } as { [key: number]: string };
 
 export interface SteamPlayerSummary {
+  steamid: string;
   avatar: string;
   avatarmedium: string;
   avatarfull: string;


### PR DESCRIPTION
Te field `steamid` is returned by the [Steam Web API's `GetPlayerSummaries` endpoint](https://partner.steamgames.com/doc/webapi/ISteamUser#GetPlayerSummaries) but being ignored by this library.